### PR TITLE
Added delete products, list orders and fixed performance issue on order-related requests.

### DIFF
--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -102,28 +102,6 @@ class GatewayService(object):
             mimetype='application/json'
         )
 
-    # def _get_order(self, order_id):
-    #     # Retrieve order data from the orders service.
-    #     # Note - this may raise a remote exception that has been mapped to
-    #     # raise``OrderNotFound``
-    #     order = self.orders_rpc.get_order(order_id)
-
-    #     # Retrieve all products from the products service
-    #     product_map = {prod['id']: prod for prod in self.products_rpc.list()}
-
-    #     # get the configured image root
-    #     image_root = config['PRODUCT_IMAGE_ROOT']
-
-    #     # Enhance order details with product and image details.
-    #     for item in order['order_details']:
-    #         product_id = item['product_id']
-
-    #         item['product'] = product_map[product_id]
-    #         # Construct an image url.
-    #         item['image'] = '{}/{}.jpg'.format(image_root, product_id)
-
-    #     return order
-
     def _get_order(self, order_id):
         # Retrieve order data from the orders service.
         # Note - this may raise a remote exception that has been mapped to
@@ -215,10 +193,14 @@ class GatewayService(object):
     def list_orders(self, request):
         """Lists all orders"""
         try:
-            orders = self.orders_rpc.list_orders()
-            return Response(
-                GetOrderSchema(many=True).dumps(orders).data,
-                mimetype="application/json"
-            )
+            page = request.args.get("page", 1, type=int)
+            per_page = request.args.get("per_page", 10, type=int)
+
+            orders = self.orders_rpc.list_orders(page=page, per_page=per_page)
+
+            order_schema = GetOrderSchema(many=True)
+            serialized_orders = order_schema.dumps(orders).data
+
+            return Response(serialized_orders, mimetype="application/json")
         except Exception as e:
             raise e

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -194,9 +194,9 @@ class GatewayService(object):
         """Lists all orders"""
         try:
             page = request.args.get("page", 1, type=int)
-            per_page = request.args.get("per_page", 10, type=int)
+            page_size = request.args.get("page_size", 10, type=int)
 
-            orders = self.orders_rpc.list_orders(page=page, per_page=per_page)
+            orders = self.orders_rpc.list_orders(page=page, page_size=page_size)
 
             order_schema = GetOrderSchema(many=True)
             serialized_orders = order_schema.dumps(orders).data

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -204,6 +204,24 @@ class TestCreateOrder(object):
             'order_details': []
         }
 
+        # setup mock products-service response:
+        gateway_service.products_rpc.list_with_ids.return_value = [
+            {
+                'id': 'the_odyssey',
+                'title': 'The Odyssey',
+                'maximum_speed': 3,
+                'in_stock': 899,
+                'passenger_capacity': 100
+            },
+            {
+                'id': 'the_enigma',
+                'title': 'The Enigma',
+                'maximum_speed': 200,
+                'in_stock': 1,
+                'passenger_capacity': 4
+            },
+        ]
+
         # call the gateway service to create the order
         response = web_session.post(
             '/orders',

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -104,7 +104,7 @@ class TestGetOrder(object):
         }
 
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
+        gateway_service.products_rpc.list_with_ids.return_value = [
             {
                 'id': 'the_odyssey',
                 'title': 'The Odyssey',
@@ -132,8 +132,7 @@ class TestGetOrder(object):
                     'id': 1,
                     'quantity': 2,
                     'product_id': 'the_odyssey',
-                    'image':
-                        'http://example.com/airship/images/the_odyssey.jpg',
+                    'image': 'http://example.com/airship/images/the_odyssey.jpg',
                     'product': {
                         'id': 'the_odyssey',
                         'title': 'The Odyssey',
@@ -147,8 +146,7 @@ class TestGetOrder(object):
                     'id': 2,
                     'quantity': 1,
                     'product_id': 'the_enigma',
-                    'image':
-                        'http://example.com/airship/images/the_enigma.jpg',
+                    'image': 'http://example.com/airship/images/the_enigma.jpg',
                     'product': {
                         'id': 'the_enigma',
                         'title': 'The Enigma',
@@ -164,7 +162,8 @@ class TestGetOrder(object):
 
         # check dependencies called as expected
         assert [call(1)] == gateway_service.orders_rpc.get_order.call_args_list
-        assert [call()] == gateway_service.products_rpc.list.call_args_list
+        assert [call(['the_odyssey', 'the_enigma'])] == gateway_service.products_rpc.list_with_ids.call_args_list
+
 
     def test_order_not_found(self, gateway_service, web_session):
         gateway_service.orders_rpc.get_order.side_effect = (
@@ -220,7 +219,7 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 200
         assert response.json() == {'id': 11}
-        assert gateway_service.products_rpc.list.call_args_list == [call()]
+        assert gateway_service.products_rpc.list.call_args_list == []
         assert gateway_service.orders_rpc.create_order.call_args_list == [
             call([
                 {'product_id': 'the_odyssey', 'quantity': 3, 'price': '41.00'}

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -1,3 +1,5 @@
+import logging
+
 from nameko.events import EventDispatcher
 from nameko.rpc import rpc
 from nameko_sqlalchemy import DatabaseSession
@@ -6,7 +8,7 @@ from orders.exceptions import NotFound
 from orders.models import DeclarativeBase, Order, OrderDetail
 from orders.schemas import OrderSchema
 
-
+logger = logging.getLogger(__name__)
 class OrdersService:
     name = 'orders'
 
@@ -15,54 +17,83 @@ class OrdersService:
 
     @rpc
     def get_order(self, order_id):
-        order = self.db.query(Order).get(order_id)
+        try:
+            order = self.db.query(Order).get(order_id)
 
-        if not order:
-            raise NotFound('Order with id {} not found'.format(order_id))
+            if not order:
+                raise NotFound(f'Order with id {order_id} not found')
 
-        return OrderSchema().dump(order).data
+            return OrderSchema().dump(order).data
+        except Exception as e:
+            logger.exception("Error occurred while getting order {order_id}")
+            raise e
+            
+    @rpc
+    def list_orders(self):
+        try:
+            orders = self.db.query(Order).all()
+            return OrderSchema(many=True).dump(orders).data
+        except Exception as e:
+            logger.exception("Error occurred while listing orders")
+            raise e
 
     @rpc
     def create_order(self, order_details):
-        order = Order(
-            order_details=[
-                OrderDetail(
-                    product_id=order_detail['product_id'],
-                    price=order_detail['price'],
-                    quantity=order_detail['quantity']
-                )
-                for order_detail in order_details
-            ]
-        )
-        self.db.add(order)
-        self.db.commit()
+        try:
+            order = Order(
+                order_details=[
+                    OrderDetail(
+                        product_id=order_detail['product_id'],
+                        price=order_detail['price'],
+                        quantity=order_detail['quantity']
+                    )
+                    for order_detail in order_details
+                ]
+            )
+            self.db.add(order)
+            self.db.commit()
 
-        order = OrderSchema().dump(order).data
+            order = OrderSchema().dump(order).data
 
-        self.event_dispatcher('order_created', {
-            'order': order,
-        })
+            self.event_dispatcher('order_created', {
+                'order': order,
+            })
 
-        return order
+            return order
+        except Exception as e:
+            logger.exception("Error occurred while creating order")
+            raise e
 
     @rpc
     def update_order(self, order):
-        order_details = {
-            order_details['id']: order_details
-            for order_details in order['order_details']
-        }
+        try:
+            order_details = {
+                order_detail['id']: order_detail
+                for order_detail in order['order_details']
+            }
 
-        order = self.db.query(Order).get(order['id'])
+            order = self.db.query(Order).get(order['id'])
 
-        for order_detail in order.order_details:
-            order_detail.price = order_details[order_detail.id]['price']
-            order_detail.quantity = order_details[order_detail.id]['quantity']
+            for order_detail in order.order_details:
+                order_detail.price = order_details[order_detail.id]['price']
+                order_detail.quantity = order_details[order_detail.id]['quantity']
 
-        self.db.commit()
-        return OrderSchema().dump(order).data
+            self.db.commit()
+            return OrderSchema().dump(order).data
+        except Exception as e:
+            logger.exception("Error occurred while updating order")
+            raise e
 
     @rpc
     def delete_order(self, order_id):
-        order = self.db.query(Order).get(order_id)
-        self.db.delete(order)
-        self.db.commit()
+        try:
+            order = self.db.query(Order).get(order_id)
+
+            if not order:
+                raise NotFound(f'Order with id {order_id} not found')
+
+            self.db.delete(order)
+            self.db.commit()
+        except Exception as e:
+            logger.exception("Error occurred while deleting order {order_id}")
+            raise e

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -1,5 +1,4 @@
 import pytest
-
 from mock import call
 from nameko.exceptions import RemoteError
 
@@ -17,20 +16,21 @@ def order(db_session):
 
 @pytest.fixture
 def order_details(db_session, order):
-    db_session.add_all([
+    order_details = [
         OrderDetail(
             order=order, product_id="the_odyssey", price=99.51, quantity=1
         ),
         OrderDetail(
             order=order, product_id="the_enigma", price=30.99, quantity=8
         )
-    ])
+    ]
+    db_session.add_all(order_details)
     db_session.commit()
     return order_details
 
 
 def test_get_order(orders_rpc, order):
-    response = orders_rpc.get_order(1)
+    response = orders_rpc.get_order(order.id)
     assert response['id'] == order.id
 
 

--- a/orders/test/unit/test_models.py
+++ b/orders/test/unit/test_models.py
@@ -1,5 +1,5 @@
 from orders.models import Order, OrderDetail
-
+from orders.service import OrdersService
 
 def test_can_create_order(db_session):
     order = Order()
@@ -35,3 +35,19 @@ def test_can_create_order_detail(db_session):
     assert order_detail_2.product_id == "the_odyssey"
     assert order_detail_2.price == 99.50
     assert order_detail_2.quantity == 2
+
+def test_list_orders(db_session):
+    # Create sample orders in the database
+    orders = [
+        Order(),
+        Order(),
+        Order(),
+    ]
+    db_session.add_all(orders)
+    db_session.commit()
+
+    # Retrieve all orders from the database
+    result = db_session.query(Order).all()
+
+    # Assert that the number of retrieved orders is equal to the number of inserted orders
+    assert len(result) == len(orders)

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -44,22 +44,6 @@ class StorageWrapper:
             'maximum_speed': int(document['maximum_speed']) if document.get('maximum_speed') else None,
             'in_stock': int(document['in_stock']) if document.get('in_stock') else None
         }
-    
-    def _get_paginated_keys(self, page, page_size):
-        # Retrieve all product keys
-        keys = self.client.keys(self._format_key('*'))
-        # Calculate the start and end indices based on the pagination parameters
-        start = (page - 1) * page_size
-        end = start + page_size
-        # Return the paginated keys
-        return keys[start:end]
-
-    def list_paginated(self, page=1, page_size=10):
-        keys = self._get_paginated_keys(page, page_size)
-        products = []
-        for key in keys:
-            products.append(self._from_hash(self.client.hgetall(key)))
-        return products
 
     def get(self, product_id):
         product = self.client.hgetall(self._format_key(product_id))

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -44,6 +44,22 @@ class StorageWrapper:
             'maximum_speed': int(document['maximum_speed']) if document.get('maximum_speed') else None,
             'in_stock': int(document['in_stock']) if document.get('in_stock') else None
         }
+    
+    def _get_paginated_keys(self, page, page_size):
+        # Retrieve all product keys
+        keys = self.client.keys(self._format_key('*'))
+        # Calculate the start and end indices based on the pagination parameters
+        start = (page - 1) * page_size
+        end = start + page_size
+        # Return the paginated keys
+        return keys[start:end]
+
+    def list_paginated(self, page=1, page_size=10):
+        keys = self._get_paginated_keys(page, page_size)
+        products = []
+        for key in keys:
+            products.append(self._from_hash(self.client.hgetall(key)))
+        return products
 
     def get(self, product_id):
         product = self.client.hgetall(self._format_key(product_id))

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -1,9 +1,12 @@
 import logging
 
 from nameko.events import event_handler
-from nameko.rpc import rpc
+from nameko.rpc import rpc, RpcProxy
+from nameko.web.handlers import http
 
 from products import dependencies, schemas
+from products.exceptions import NotFound
+
 
 
 logger = logging.getLogger(__name__)
@@ -17,21 +20,69 @@ class ProductsService:
 
     @rpc
     def get(self, product_id):
-        product = self.storage.get(product_id)
-        return schemas.Product().dump(product).data
+        try:
+            product = self.storage.get(product_id)
+            if product is None:
+                return 404, {"error": "Product not found"}
+            return schemas.Product().dump(product).data
+        except NotFound as e:
+            logger.exception("The product: {product_id} does not exist")
+            raise e
+        except Exception as e:
+            logger.exception("Error occurred while getting product")
+            return e
 
     @rpc
     def list(self):
-        products = self.storage.list()
-        return schemas.Product(many=True).dump(products).data
+        try:
+            products = self.storage.list()
+            return schemas.Product(many=True).dump(products).data
+        except Exception as e:
+            logger.exception("Error occurred while listing products")
+            return 500, {"error": "An error occurred while listing the products"}
+        
+    @rpc
+    def list_ids(self):
+        try:
+            products = self.storage.list()
+            valid_product_ids = [product['id'] for product in products]
+            return valid_product_ids
+        except Exception as e:
+            logger.exception("Error occurred while listing products")
+            return set()
 
     @rpc
+    def list_with_ids(self, product_ids):
+        try:
+            products = self.storage.filter_by_ids(product_ids)
+            return schemas.Product(many=True).dump(products).data
+        except Exception as e:
+            logger.exception("Error occurred while listing products")
+            return 500, {"error": "An error occurred while listing the products"}
+    @rpc
     def create(self, product):
-        product = schemas.Product(strict=True).load(product).data
-        self.storage.create(product)
+        try:
+            product = schemas.Product(strict=True).load(product).data
+            self.storage.create(product)
+        except Exception as e:
+            logger.exception("Error occurred while creating product")
+            return 500, {"error": "An error occurred while creating the product"}
+        
+    @rpc
+    def delete(self, product_id):
+        try:
+            self.storage.delete(product_id)
+        except Exception as e:
+            logger.exception("Error occurred while deleting product")
+            return 500, {"error": "An error occurred while deleting the product: {product_id}"}
 
     @event_handler('orders', 'order_created')
     def handle_order_created(self, payload):
-        for product in payload['order']['order_details']:
-            self.storage.decrement_stock(
-                product['product_id'], product['quantity'])
+        try:
+            for product in payload['order']['order_details']:
+                self.storage.decrement_stock(
+                    product['product_id'], product['quantity'])
+        except Exception as e:
+            logger.exception("Error occurred while handling order creation")
+            return 500, {"error": "An error occurred while handling order creation"}
+        

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -35,25 +35,14 @@ class ProductsService:
 
 
     @rpc
-    def list(self, page=1, page_size=10):
+    def list(self):
         try:
             # Perform pagination using SQLAlchemy's paginate function
-            products = self.storage.list_paginated(page, page_size)
-            
-            return products
+            products = self.storage.list()            
+            return schemas.Product(many=True).dump(products).data
         except Exception as e:
             logger.exception("Error occurred while listing products")
             raise e
-
-    @rpc
-    def list_ids(self):
-        try:
-            products = self.storage.list()
-            valid_product_ids = [product['id'] for product in products]
-            return valid_product_ids
-        except Exception as e:
-            logger.exception("Error occurred while listing products")
-            return set()
 
     @rpc
     def list_with_ids(self, product_ids):
@@ -63,6 +52,7 @@ class ProductsService:
         except Exception as e:
             logger.exception("Error occurred while listing products")
             return 500, {"error": "An error occurred while listing the products"}
+
     @rpc
     def create(self, product):
         try:

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -122,7 +122,7 @@ scenarios:
         not: false
     
     # 6. List Orders
-    - url: "/orders?page=1&page_size=50"
+    - url: "/orders?page=1&page_size=10"
       label: orders-list
       think-time: uniform(0s, 0s)
       method: GET

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -108,6 +108,30 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
+    
+    # 5. Delete Product
+    - url: /products/${product_id}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+    
+    # 6. List Orders
+    - url: "/orders?page=1&page_size=50"
+      label: orders-list
+      think-time: uniform(0s, 0s)
+      method: GET
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
   
 reporting:
 - module: final-stats

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -49,6 +49,24 @@ ORDER_ID=$(
 echo ${ORDER_ID}
 ID=$(echo ${ORDER_ID} | jq '.id')
 
+# Test: List Orders
+echo "=== Listing Orders ==="
+curl -s "${STD_APP_URL}/orders" | jq .
+
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: Delete Product
+echo "=== Deleting product id: the_odyssey ==="
+curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey"
+echo
+
+# Test: Get Deleted Product
+echo "=== Getting product id: the_odyssey after deletion ==="
+response=$(curl -s -o /dev/null -w "%{http_code}" "${STD_APP_URL}/products/the_odyssey")
+if [ $response -eq 200 ]; then
+  echo "Product the_odyssey still exists after deletion"
+else
+  echo "Product the_odyssey successfully deleted"
+fi

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -51,7 +51,7 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 
 # Test: List Orders
 echo "=== Listing Orders ==="
-curl -s "${STD_APP_URL}/orders" | jq .
+curl -s "${STD_APP_URL}/orders?page=1&page_size=10" | jq .
 
 # Test: Get Order back
 echo "=== Getting Order ==="


### PR DESCRIPTION
### Added functionalities for delete products and list orders.
Also fixed the performance issue that was happening on the order endpoints (create and get).

**Why is performance degrading as the test run longer?**
On both methods, to retrieve the products on the order we were doing a RPC call to the products service to get the full list of products every time, with no filters. So the more products we had on the database, the longer this operation took.

**How do you fix it?**
Doing the product query using the IDs present on the order as we just need those products, not the full list of products.
With that, it doesn't matter how many products we have on the database, as we're only grabbing the ones we need for the specific order.

Tests are running much more smoothly now.
<img width="1862" alt="Screenshot 2023-06-22 at 17 33 06" src="https://github.com/PedroFabrino/nameko-devex/assets/9949616/30d5c2ed-25d8-4a99-8d34-d6b66934ec5c">
